### PR TITLE
feat: switch to iter.Seq for digests to publish

### DIFF
--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"iter"
-	"slices"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
@@ -27,7 +26,7 @@ var log = logging.Logger("publisher")
 type Publisher interface {
 	// Publish creates, signs and publishes an advert. It then announces the new
 	// advert to other indexers.
-	Publish(ctx context.Context, provider peer.AddrInfo, contextID string, digests []mh.Multihash, meta metadata.Metadata) (ipld.Link, error)
+	Publish(ctx context.Context, provider peer.AddrInfo, contextID string, digests iter.Seq[mh.Multihash], meta metadata.Metadata) (ipld.Link, error)
 }
 
 type IPNIPublisher struct {
@@ -37,8 +36,8 @@ type IPNIPublisher struct {
 	store  store.PublisherStore
 }
 
-func (p *IPNIPublisher) Publish(ctx context.Context, providerInfo peer.AddrInfo, contextID string, digests []mh.Multihash, meta metadata.Metadata) (ipld.Link, error) {
-	link, err := p.publishAdvForIndex(ctx, providerInfo.ID, providerInfo.Addrs, []byte(contextID), meta, false, slices.Values(digests))
+func (p *IPNIPublisher) Publish(ctx context.Context, providerInfo peer.AddrInfo, contextID string, digests iter.Seq[mh.Multihash], meta metadata.Metadata) (ipld.Link, error) {
+	link, err := p.publishAdvForIndex(ctx, providerInfo.ID, providerInfo.Addrs, []byte(contextID), meta, false, digests)
 	if err != nil {
 		return nil, fmt.Errorf("publishing IPNI advert: %w", err)
 	}

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -3,6 +3,7 @@ package publisher
 import (
 	"context"
 	"math/rand/v2"
+	"slices"
 	"sort"
 	"testing"
 
@@ -37,7 +38,7 @@ func TestPublish(t *testing.T) {
 		require.NoError(t, err)
 
 		digests := testutil.RandomMultihashes(rand.IntN(10) + 1)
-		adlnk, err := publisher.Publish(ctx, provInfo, testutil.RandomCID().String(), digests, metadata.Default.New())
+		adlnk, err := publisher.Publish(ctx, provInfo, testutil.RandomCID().String(), slices.Values(digests), metadata.Default.New())
 		require.NoError(t, err)
 
 		ad, err := st.Advert(ctx, adlnk)
@@ -59,7 +60,7 @@ func TestPublish(t *testing.T) {
 		require.NoError(t, err)
 
 		digests := testutil.RandomMultihashes(store.MaxEntryChunkSize + 1)
-		adlnk, err := publisher.Publish(ctx, provInfo, testutil.RandomCID().String(), digests, metadata.Default.New())
+		adlnk, err := publisher.Publish(ctx, provInfo, testutil.RandomCID().String(), slices.Values(digests), metadata.Default.New())
 		require.NoError(t, err)
 
 		ad, err := st.Advert(ctx, adlnk)
@@ -95,7 +96,7 @@ func TestPublish(t *testing.T) {
 			ctxid := testutil.RandomCID().String()
 			digests := testutil.RandomMultihashes(1 + rand.IntN(100))
 
-			l, err := publisher.Publish(ctx, provInfo, ctxid, digests, metadata.Default.New())
+			l, err := publisher.Publish(ctx, provInfo, ctxid, slices.Values(digests), metadata.Default.New())
 			require.NoError(t, err)
 
 			adLinks = append(adLinks, l)


### PR DESCRIPTION
Small tweak to make interface amenable to not buffering digests in memory.