### PR TITLE
docs: clarify IPNIPublisher is not thread-safe by default

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
+	dssync "github.com/ipfs/go-datastore/sync"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/storacha/ipni-publisher/pkg/notifier"
@@ -22,8 +23,8 @@ var notifierNamespace = ipniNamespace.ChildString("notifier/")
 func TestExample(t *testing.T) {
 	priv, _, _ := crypto.GenerateEd25519Key(nil)
 
-	// Setup publisher
-	ds := datastore.NewMapDatastore()
+	// Setup a thread-safe publisher using a thread-safe datastore
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	publisherStore := store.FromDatastore(namespace.Wrap(ds, publisherNamespace))
 	publisher, _ := publisher.New(
 		priv,

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
-	dssync "github.com/ipfs/go-datastore/sync"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/storacha/ipni-publisher/pkg/notifier"
@@ -23,8 +22,8 @@ var notifierNamespace = ipniNamespace.ChildString("notifier/")
 func TestExample(t *testing.T) {
 	priv, _, _ := crypto.GenerateEd25519Key(nil)
 
-	// Setup a thread-safe publisher using a thread-safe datastore
-	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	// Setup publisher
+	ds := datastore.NewMapDatastore()
 	publisherStore := store.FromDatastore(namespace.Wrap(ds, publisherNamespace))
 	publisher, _ := publisher.New(
 		priv,

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -50,7 +50,7 @@ func (p *IPNIPublisher) Publish(ctx context.Context, providerInfo peer.AddrInfo,
 var _ Publisher = (*IPNIPublisher)(nil)
 
 // New creates a new IPNI publisher.
-// IPNIPublisher is not safe for concurrent use. There is the risk of loosing advertisements if Publish is called
+// IPNIPublisher is not safe for concurrent use. There is the risk of losing advertisements if Publish is called
 // from concurrent goroutines. If you will be publishing from multiple goroutines concurrently, a synchronization
 // mechanism (such as sync.Mutex) must be used to ensure that Publish is called serially.
 func New(id crypto.PrivKey, store store.PublisherStore, opts ...Option) (*IPNIPublisher, error) {

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -46,6 +46,11 @@ func (p *IPNIPublisher) Publish(ctx context.Context, providerInfo peer.AddrInfo,
 
 var _ Publisher = (*IPNIPublisher)(nil)
 
+// New creates a new IPNI publisher.
+// Thread-safety of the publisher will depend on the underlying store. If you will be calling Publish from different
+// goroutines (which is likely), make sure to use a thread-safe store when creating the publisher. A simple way of
+// getting one is using the `github.com/ipfs/go-datastore/sync` package, which offers `sync.MutexDatastore` that wraps
+// any given datastore with a RWMutex.
 func New(id crypto.PrivKey, store store.PublisherStore, opts ...Option) (*IPNIPublisher, error) {
 	o := &options{
 		topic: "/indexer/ingest/mainnet",

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -36,6 +36,9 @@ type IPNIPublisher struct {
 	store  store.PublisherStore
 }
 
+// Publish creates a new advertisement from the latest head, signs it, and publishes it.
+// Publish is not safe for concurrent use and advertisements may be lost if called concurrently. A mutex or any other
+// synchronization mechanism must be used around Publish if it will be called from concurrent goroutines.
 func (p *IPNIPublisher) Publish(ctx context.Context, providerInfo peer.AddrInfo, contextID string, digests iter.Seq[mh.Multihash], meta metadata.Metadata) (ipld.Link, error) {
 	link, err := p.publishAdvForIndex(ctx, providerInfo.ID, providerInfo.Addrs, []byte(contextID), meta, false, digests)
 	if err != nil {
@@ -47,10 +50,9 @@ func (p *IPNIPublisher) Publish(ctx context.Context, providerInfo peer.AddrInfo,
 var _ Publisher = (*IPNIPublisher)(nil)
 
 // New creates a new IPNI publisher.
-// Thread-safety of the publisher will depend on the underlying store. If you will be calling Publish from different
-// goroutines (which is likely), make sure to use a thread-safe store when creating the publisher. A simple way of
-// getting one is using the `github.com/ipfs/go-datastore/sync` package, which offers `sync.MutexDatastore` that wraps
-// any given datastore with a RWMutex.
+// IPNIPublisher is not safe for concurrent use. There is the risk of loosing advertisements if Publish is called
+// from concurrent goroutines. If you will be publishing from multiple goroutines concurrently, a synchronization
+// mechanism (such as sync.Mutex) must be used to ensure that Publish is called serially.
 func New(id crypto.PrivKey, store store.PublisherStore, opts ...Option) (*IPNIPublisher, error) {
 	o := &options{
 		topic: "/indexer/ingest/mainnet",


### PR DESCRIPTION
`IPNIPublisher.Publish` stores advertisements in the configured store. Calling `Publish` from different goroutines could lead to advertisements being lost if the underlying store is not thread-safe.

This PR adds a comment to warn about this.

Resolves #3