### PR TITLE
fix: base58btc encode the context ID in datastore key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ipni/go-libipni v0.6.13
 	github.com/libp2p/go-libp2p v0.36.5
 	github.com/multiformats/go-multiaddr v0.13.0
+	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.0.7
@@ -38,7 +39,6 @@ require (
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
-	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/pion/ice/v2 v2.3.35 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/ipni/go-libipni/metadata"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-ucanto/core/ipld/block"
 	"github.com/storacha/go-ucanto/core/ipld/codec/json"
@@ -397,7 +398,8 @@ func IsNotFound(err error) bool {
 }
 
 func providerContextKey(provider peer.ID, contextID []byte) datastore.Key {
-	return datastore.NewKey(provider.String() + "/" + string(contextID))
+	contextKey, _ := multibase.Encode(multibase.Base58BTC, contextID)
+	return datastore.NewKey(provider.String() + "/" + contextKey)
 }
 
 type dsProviderContextTable struct {


### PR DESCRIPTION
The PR base58btc encodes the contect ID in the datastore key so it can be used in regular string based KV stores.